### PR TITLE
Add Priority field for MX and SRV records

### DIFF
--- a/api.go
+++ b/api.go
@@ -93,11 +93,12 @@ func (r reclist) lsrec() (*resty.Response, error) {
 // they come back in a completely different format
 // in this case we currently ignore failover, status and dynamicurl_status
 type retrec struct {
-	ID     string `json:"id"`
-	Host   string `json:"host"`
-	Rtype  string `json:"type"`
-	TTL    string `json:"ttl"`
-	Record string `json:"record"`
+	ID       string `json:"id"`
+	Host     string `json:"host"`
+	Rtype    string `json:"type"`
+	TTL      string `json:"ttl"`
+	Record   string `json:"record"`
+	Priority string `json:"priority,omitempty"`
 }
 
 //zonelist struct to lists zones, see https://www.cloudns.net/wiki/article/50/

--- a/cloudns.go
+++ b/cloudns.go
@@ -73,13 +73,15 @@ func (z Zone) List(a *Apiaccess) ([]Record, error) {
 		err2 := json.Unmarshal(resp.Body(), &ratmp)
 		for _, rec := range ratmp {
 			tmpttl, _ := strconv.Atoi(rec.TTL)
+			tmppriority, _ := strconv.Atoi(rec.Priority)
 			rectmp := Record{
-				Domain: z.Domain,
-				ID:     rec.ID,
-				Rtype:  rec.Rtype,
-				Host:   rec.Host,
-				TTL:    tmpttl,
-				Record: rec.Record,
+				Domain:   z.Domain,
+				ID:       rec.ID,
+				Rtype:    rec.Rtype,
+				Host:     rec.Host,
+				TTL:      tmpttl,
+				Record:   rec.Record,
+				Priority: tmppriority,
 			}
 			ra = append(ra, rectmp)
 		}
@@ -167,12 +169,13 @@ func (z Zone) Destroy(a *Apiaccess) (Zone, error) {
 // Record is the external representation of a record
 // check the ...record types in api.go for details
 type Record struct {
-	ID     string `json:"id"`
-	Domain string `json:"domain-name"`
-	Host   string `json:"host"`
-	Rtype  string `json:"record-type"`
-	TTL    int    `json:"ttl"`
-	Record string `json:"record"`
+	ID       string `json:"id"`
+	Domain   string `json:"domain-name"`
+	Host     string `json:"host"`
+	Rtype    string `json:"record-type"`
+	TTL      int    `json:"ttl"`
+	Record   string `json:"record"`
+	Priority int    `json:"priority,omitempty"`
 }
 
 // Create a new record
@@ -186,6 +189,7 @@ func (r Record) Create(a *Apiaccess) (Record, error) {
 		Rtype:        r.Rtype,
 		TTL:          r.TTL,
 		Record:       r.Record,
+		Priority:     r.Priority,
 	}
 	resp, err := inr.create()
 	if err == nil {
@@ -219,13 +223,15 @@ func (r Record) Read(a *Apiaccess) (Record, error) {
 		err2 := json.Unmarshal(resp.Body(), &ratmp)
 		for _, rec := range ratmp {
 			tmpttl, _ := strconv.Atoi(rec.TTL)
+			tmppriority, _ := strconv.Atoi(rec.Priority)
 			rectmp := Record{
-				Domain: r.Domain,
-				ID:     rec.ID,
-				Rtype:  rec.Rtype,
-				Host:   rec.Host,
-				TTL:    tmpttl,
-				Record: rec.Record,
+				Domain:   r.Domain,
+				ID:       rec.ID,
+				Rtype:    rec.Rtype,
+				Host:     rec.Host,
+				TTL:      tmpttl,
+				Record:   rec.Record,
+				Priority: tmppriority,
 			}
 			if r.ID != "" && r.ID == rectmp.ID {
 				return rectmp, err2
@@ -250,6 +256,7 @@ func (r Record) Update(a *Apiaccess) (Record, error) {
 		Host:         r.Host,
 		TTL:          r.TTL,
 		Record:       r.Record,
+		Priority:     r.Priority,
 	}
 	resp, err := inr.update()
 	if err == nil {


### PR DESCRIPTION
Priority field is required for MX and SRV records https://www.cloudns.net/wiki/article/58/

CloudDNS API doesn't allow creating MX record without providing Priority field.


