### PR TITLE
Allow setting "Priority: 0" for MX and SRV records

### DIFF
--- a/api.go
+++ b/api.go
@@ -128,7 +128,7 @@ type createrec struct {
 	TTL            int    `json:"ttl"`
 	Host           string `json:"host"`
 	Record         string `json:"record"`
-	Priority       int    `json:"priority,omitempty"`
+	Priority       *int   `json:"priority,omitempty"`
 	Weight         int    `json:"weight,omitempty"`
 	Port           int    `json:"port,omitempty"`
 	Frame          int    `json:"frame,omitempty"`
@@ -180,7 +180,7 @@ type updaterec struct {
 	TTL            int    `json:"ttl"`
 	Host           string `json:"host"`
 	Record         string `json:"record"`
-	Priority       int    `json:"priority,omitempty"`
+	Priority       *int   `json:"priority,omitempty"`
 	Weight         int    `json:"weight,omitempty"`
 	Port           int    `json:"port,omitempty"`
 	Frame          int    `json:"frame,omitempty"`

--- a/cloudns.go
+++ b/cloudns.go
@@ -189,7 +189,9 @@ func (r Record) Create(a *Apiaccess) (Record, error) {
 		Rtype:        r.Rtype,
 		TTL:          r.TTL,
 		Record:       r.Record,
-		Priority:     r.Priority,
+	}
+	if r.Rtype == "MX" || r.Rtype == "SRV" {
+		inr.Priority = &r.Priority
 	}
 	resp, err := inr.create()
 	if err == nil {
@@ -256,7 +258,9 @@ func (r Record) Update(a *Apiaccess) (Record, error) {
 		Host:         r.Host,
 		TTL:          r.TTL,
 		Record:       r.Record,
-		Priority:     r.Priority,
+	}
+	if r.Rtype == "MX" || r.Rtype == "SRV" {
+		inr.Priority = &r.Priority
 	}
 	resp, err := inr.update()
 	if err == nil {


### PR DESCRIPTION
I have noticed that #1 doesn't allow setting `Priority: 0`, because `omitempty` also treats 0 as emty.

CloudDNS API accepts priority between 0 and 65535 where:
  - 0 is the highest priority
  - 10 is the default value in UI

This can be fixed by using `Priority *int` in the internal structs, while keeping `Priority  int` in the public `Record` struct for safety and convenience ([`*int` behaves as Option type][1]).

[1]: https://stackoverflow.com/questions/38486564/unmarshal-marshal-json-with-int-set-to-0-does-not-seem-to-work